### PR TITLE
Run CI on merges to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
 on:
+  push:
+    branches: [main]
   pull_request: {}
 
 jobs:


### PR DESCRIPTION
Previously we only ran CI on PRs, this change makes it so that CI also runs on main.