### PR TITLE
Don't run clippy on deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Build
         run: cargo build --verbose
       - name: Lint
-        run: cargo clippy --frozen --all-features -- -Dwarnings
+        run: cargo clippy --no-deps --frozen --all-features -- -Dwarnings
       - name: Test
         run: cargo test --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,7 @@ jobs:
         run: cargo build --verbose
       - name: Lint
         run: cargo clippy --no-deps --frozen --all-features -- -Dwarnings
+      - name: Check Formatting
+        run: cargo fmt --check
       - name: Test
         run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ sha256 = "1.5.0"
 inherits = "release"
 lto = "thin"
 
-
 # Config for 'cargo dist'
 [workspace.metadata.dist]
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ sha256 = "1.5.0"
 inherits = "release"
 lto = "thin"
 
+
 # Config for 'cargo dist'
 [workspace.metadata.dist]
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 use std::{
     collections::{BTreeMap, HashMap},
     error::Error,
+    fmt::Display,
     fs,
 };
 
@@ -85,21 +86,15 @@ struct Binary {
     binaries: Vec<BinaryUnion>,
 }
 
-impl ToString for SupportedCpu {
-    fn to_string(&self) -> String {
-        match &self {
-            SupportedCpu::Arm64 => "arm64".to_string(),
-            SupportedCpu::X86_64 => "x86_64".to_string(),
-        }
+impl Display for SupportedCpu {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self)
     }
 }
 
-impl ToString for SupportedOs {
-    fn to_string(&self) -> String {
-        match &self {
-            SupportedOs::Linux => "linux".to_string(),
-            SupportedOs::MacOS => "macos".to_string(),
-        }
+impl Display for SupportedOs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,13 +88,19 @@ struct Binary {
 
 impl Display for SupportedCpu {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self)
+        match &self {
+            SupportedCpu::Arm64 => write!(f, "arm64"),
+            SupportedCpu::X86_64 => write!(f, "x86_64"),
+        }
     }
 }
 
 impl Display for SupportedOs {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self)
+        match &self {
+            SupportedOs::Linux => write!(f, "linux"),
+            SupportedOs::MacOS => write!(f, "macos"),
+        }
     }
 }
 


### PR DESCRIPTION
CI is running clippy on everything, but realistically we only care about the current crate.
