### PR TITLE
Also renovate Cargo.lock

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,5 +5,8 @@
   "schedule": ["every weekday after 9am before 5pm"],
   "branchConcurrentLimit": 10,
   "labels": ["automerge"],
-  "dependencyDashboard": true
+  "dependencyDashboard": true,
+  "cargo": {
+    "fileMatch": ["^Cargo\\.(lock|toml)$"]
+  }
 }


### PR DESCRIPTION
We were not renovating Cargo.lock, this PR enables renovating both Cargo.toml and Cargo.lock.
